### PR TITLE
Add ca-certificates and make CMD command stable

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,4 +10,4 @@ RUN dpkg -i /tmp/o365beat-1.5.1-amd64.deb
 
 COPY o365beat.yml /etc/o365beat/
 
-CMD ["/bin/bash", "-c", "/usr/share/o365beat/bin/o365beat --e --c=o365beat.yml --path.home=/usr/share/o365beat --path.config=/etc/o365beat --path.data=/var/lib/o365beat --path.logs=/var/log/o365beat"]
+CMD ["/usr/share/o365beat/bin/o365beat --e --c=o365beat.yml --path.home=/usr/share/o365beat --path.config=/etc/o365beat --path.data=/var/lib/o365beat --path.logs=/var/log/o365beat"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,13 @@
 FROM ubuntu:18.04
 
+RUN apt-get update && \
+  apk-get install -y ca-certificates && \
+  rm -rf /var/lib/apt/lists/*
+
 ADD https://github.com/counteractive/o365beat/releases/download/v1.5.1/o365beat-1.5.1-amd64.deb /tmp
 
 RUN dpkg -i /tmp/o365beat-1.5.1-amd64.deb
 
 COPY o365beat.yml /etc/o365beat/
 
-CMD ["/usr/share/o365beat/bin/o365beat -e -c /etc/o365beat/o365beat.yml -path.home /usr/share/o365beat -path.config /etc/o365beat -path.data /var/lib/o365beat -path.logs /var/log/o365beat"]
+CMD ["/bin/bash", "-c", "/usr/share/o365beat/bin/o365beat", "--e", "--c=o365beat.yml",  "--path.home=/usr/share/o365beat", "--path.config=/etc/o365beat", "--path.data=/var/lib/o365beat", "--path.logs=/var/log/o365beat"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,4 +10,4 @@ RUN dpkg -i /tmp/o365beat-1.5.1-amd64.deb
 
 COPY o365beat.yml /etc/o365beat/
 
-CMD ["/bin/bash", "-c", "/usr/share/o365beat/bin/o365beat", "--e", "--c=o365beat.yml",  "--path.home=/usr/share/o365beat", "--path.config=/etc/o365beat", "--path.data=/var/lib/o365beat", "--path.logs=/var/log/o365beat"]
+CMD ["/bin/bash", "-c", "/usr/share/o365beat/bin/o365beat --e --c=o365beat.yml --path.home=/usr/share/o365beat --path.config=/etc/o365beat --path.data=/var/lib/o365beat --path.logs=/var/log/o365beat"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM ubuntu:18.04
 
 RUN apt-get update && \
-  apk-get install -y ca-certificates && \
+  apt-get install -y ca-certificates && \
   rm -rf /var/lib/apt/lists/*
 
 ADD https://github.com/counteractive/o365beat/releases/download/v1.5.1/o365beat-1.5.1-amd64.deb /tmp


### PR DESCRIPTION
ca-certificates package is required, as without it you can't make authentication attempts to [microsoft](https://login.microsoftonline.com/<tenant-name>/oauth2/token?api-version=1.0) as it fails with "X509: certificate signed by unknown authority" error.

Also I modified CMD command to use full config qualifiers and corrected '-c' flag to use relative path to a configuration.